### PR TITLE
chore: Move `react-native-async-storage` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A react native emoji selector",
   "main": "index.tsx",
   "types": "./index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/taskade/react-native-emoji-selector.git"
+  },
   "scripts": {
     "prettify": "prettier --write './**/*.js'"
   },
@@ -14,13 +18,12 @@
   "author": "Arron Hunt",
   "license": "MIT",
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.13.3",
     "@taskade/eslint-plugin": "^0.2.0",
     "emoji-datasource": "^6.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/taskade/react-native-emoji-selector.git"
+  "peerDependencies": {
+    "@react-native-async-storage/async-storage": "^1.13.0",
+    "react-native": ">=0.64.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,13 +795,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@react-native-async-storage/async-storage@^1.13.3":
-  version "1.15.4"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.4.tgz#cdba464ca3bb9f10ec538342cbf2520c06f453ab"
-  integrity sha512-pC0MS6UBuv/YiVAxtzi7CgUed8oCQNYMtGt0yb/I9fI/BWTiJK5cj4YtW2XtL95K5IuvPX/6uGWaouZ8KqXwdg==
-  dependencies:
-    deep-assign "^3.0.0"
-
 "@taskade/eslint-plugin@^0.2.0":
   version "0.2.0"
   resolved "https://npm.pkg.github.com/download/@taskade/eslint-plugin/0.2.0/621395544a30d75cc5ee7ee8acd1f78a5d6dac2b02913c999dafa366bf181edb#ee281871e130f61a534c9a0061b7043631384cda"
@@ -1263,13 +1256,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
-
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
 
 deep-is@^0.1.3:
   version "0.1.3"
@@ -1904,11 +1890,6 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
 is-regex@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Purpose

The aim is to reduce the overall module size by moving `react-native-async-storage` to a `peerDependency`. Package users now need to install `react-native-async-storage` as well.

